### PR TITLE
Improve frontend UX and backend tests

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -409,7 +409,7 @@ mod tests {
     async fn health_works() {
         let conn = Connection::open_in_memory().unwrap();
         init_db(&conn);
-        let data = web::Data::new(AppState { db: Mutex::new(conn) });
+        let data = web::Data::new(AppState { db: Mutex::new(conn), sessions: Arc::new(Mutex::new(HashMap::new())) });
         let app = test::init_service(
             App::new()
                 .app_data(data.clone())
@@ -428,7 +428,7 @@ mod tests {
     async fn create_and_list_cells() {
         let conn = Connection::open_in_memory().unwrap();
         init_db(&conn);
-        let data = web::Data::new(AppState { db: Mutex::new(conn) });
+        let data = web::Data::new(AppState { db: Mutex::new(conn), sessions: Arc::new(Mutex::new(HashMap::new())) });
         let app = test::init_service(
             App::new()
                 .app_data(data.clone())
@@ -459,7 +459,7 @@ mod tests {
     async fn evaluate_formula() {
         let conn = Connection::open_in_memory().unwrap();
         init_db(&conn);
-        let data = web::Data::new(AppState { db: Mutex::new(conn) });
+        let data = web::Data::new(AppState { db: Mutex::new(conn), sessions: Arc::new(Mutex::new(HashMap::new())) });
         let app = test::init_service(
             App::new()
                 .app_data(data.clone())
@@ -481,7 +481,7 @@ mod tests {
     async fn evaluate_average() {
         let conn = Connection::open_in_memory().unwrap();
         init_db(&conn);
-        let data = web::Data::new(AppState { db: Mutex::new(conn) });
+        let data = web::Data::new(AppState { db: Mutex::new(conn), sessions: Arc::new(Mutex::new(HashMap::new())) });
         let app = test::init_service(
             App::new()
                 .app_data(data.clone())
@@ -503,7 +503,7 @@ mod tests {
     async fn set_formula_cell() {
         let conn = Connection::open_in_memory().unwrap();
         init_db(&conn);
-        let data = web::Data::new(AppState { db: Mutex::new(conn) });
+        let data = web::Data::new(AppState { db: Mutex::new(conn), sessions: Arc::new(Mutex::new(HashMap::new())) });
         let app = test::init_service(
             App::new()
                 .app_data(data.clone())

--- a/backend/test_api.sh
+++ b/backend/test_api.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Simple integration test for the AIXcel backend using curl
+# Usage: ./test_api.sh [BASE_URL]
+# Default BASE_URL is http://localhost:6889
+
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:6889}"
+
+pass() { echo -e "\e[32mPASS\e[0m - $1"; }
+fail() { echo -e "\e[31mFAIL\e[0m - $1"; exit 1; }
+
+check_health() {
+  local res
+  res=$(curl -sf "$BASE_URL/health" || fail "health endpoint unreachable")
+  if [[ "$res" == "ok" ]]; then
+    pass "health"
+  else
+    fail "health returned '$res'"
+  fi
+}
+
+list_cells() {
+  curl -sf "$BASE_URL/cells" | jq -e '.' >/dev/null || fail "list cells"
+  pass "list cells"
+}
+
+add_cell() {
+  curl -sf -X POST "$BASE_URL/cells" -H 'Content-Type: application/json' \
+    -d '{"row":0,"col":0,"value":"42"}' >/dev/null || fail "add cell"
+  pass "add cell"
+}
+
+evaluate_formula() {
+  local res
+  res=$(curl -sf -X POST "$BASE_URL/evaluate" -H 'Content-Type: application/json' \
+    -d '{"expr":"=SUM(1,2,3)"}' || fail "evaluate")
+  if [[ "$res" == "6" ]]; then
+    pass "evaluate formula"
+  else
+    fail "evaluate returned '$res'"
+  fi
+}
+
+clear_cell() {
+  curl -sf -X POST "$BASE_URL/cells/clear" -H 'Content-Type: application/json' \
+    -d '{"cells":[{"row":0,"col":0}]}' >/dev/null || fail "clear cell"
+  pass "clear cell"
+}
+
+check_empty() {
+  local count
+  count=$(curl -sf "$BASE_URL/cells" | jq 'length') || fail "count cells"
+  if [[ "$count" -eq 0 ]]; then
+    pass "database empty"
+  else
+    fail "expected 0 cells, got $count"
+  fi
+}
+
+check_health
+list_cells
+add_cell
+list_cells
+evaluate_formula
+clear_cell
+check_empty
+
+echo "All tests passed."


### PR DESCRIPTION
## Summary
- allow configuring API URL via `NEXT_PUBLIC_API_BASE_URL`
- update websocket URL logic
- update cell update functions to mutate local state instead of refetching
- start editing a cell when typing with a selection
- update backend tests to provide websocket session map
- add cURL-based integration test script

## Testing
- `cargo test --manifest-path backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68531c817e0c8330b32995019c4a9ad6